### PR TITLE
Implement environment-aware PWA caching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,5 +119,11 @@ Before any commit:
 ### CSS Guidelines
 - Always put styles in style.css, never inline
 
+### PWA Caching Control
+Development caching behavior can be controlled via URL parameters:
+- Default: No caching on localhost/127.0.0.1/192.168.x (dev-friendly)
+- `?cache=force` - Enable caching on local development
+- `?cache=disable` - Disable caching in production (for testing)
+
 ### Implementation Planning Process
 When asked to plan an implementation, follow the standardized process documented in `PLANNING.md`.

--- a/public_html/search.js
+++ b/public_html/search.js
@@ -189,17 +189,18 @@ async function registerServiceWorker(windowObj = window) {
 
 function shouldEnableCaching(windowObj = window) {
   const urlParams = new URLSearchParams(windowObj.location.search);
-  const cacheParam = urlParams.get('cache');
-  
+  const cacheParam = urlParams.get("cache");
+
   // Explicit override via URL parameter
-  if (cacheParam === 'force') return true;
-  if (cacheParam === 'disable') return false;
-  
+  if (cacheParam === "force") return true;
+  if (cacheParam === "disable") return false;
+
   // Default: disable caching on local development
-  const isLocal = windowObj.location.hostname === 'localhost' ||
-                  windowObj.location.hostname === '127.0.0.1' ||
-                  windowObj.location.hostname.startsWith('192.168.');
-  
+  const isLocal =
+    windowObj.location.hostname === "localhost" ||
+    windowObj.location.hostname === "127.0.0.1" ||
+    windowObj.location.hostname.startsWith("192.168.");
+
   return !isLocal;
 }
 

--- a/public_html/search.js
+++ b/public_html/search.js
@@ -187,8 +187,24 @@ async function registerServiceWorker(windowObj = window) {
   }
 }
 
+function shouldEnableCaching(windowObj = window) {
+  const urlParams = new URLSearchParams(windowObj.location.search);
+  const cacheParam = urlParams.get('cache');
+  
+  // Explicit override via URL parameter
+  if (cacheParam === 'force') return true;
+  if (cacheParam === 'disable') return false;
+  
+  // Default: disable caching on local development
+  const isLocal = windowObj.location.hostname === 'localhost' ||
+                  windowObj.location.hostname === '127.0.0.1' ||
+                  windowObj.location.hostname.startsWith('192.168.');
+  
+  return !isLocal;
+}
+
 function initializePWA(windowObj = window) {
-  if (isServiceWorkerSupported(windowObj)) {
+  if (isServiceWorkerSupported(windowObj) && shouldEnableCaching(windowObj)) {
     registerServiceWorker(windowObj);
   }
 }
@@ -310,5 +326,6 @@ if (typeof module !== "undefined" && module.exports) {
     showSaveMessage,
     setupSettingsEventListeners,
     initializeSettings,
+    shouldEnableCaching,
   };
 }

--- a/public_html/service-worker-lib.js
+++ b/public_html/service-worker-lib.js
@@ -1,4 +1,4 @@
-const STATIC_CACHE_NAME = "just-bangs-static-v6";
+const STATIC_CACHE_NAME = "just-bangs-static-v7";
 
 const STATIC_ASSETS = [
   "./",

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -814,19 +814,27 @@ describe("Settings Functions", () => {
     const testCases = [
       // [hostname, queryString, expected, description]
       ["localhost", "?cache=force", true, "cache=force parameter returns true"],
-      ["example.com", "?cache=disable", false, "cache=disable parameter returns false"],
+      [
+        "example.com",
+        "?cache=disable",
+        false,
+        "cache=disable parameter returns false",
+      ],
       ["localhost", "", false, "localhost hostname returns false"],
       ["127.0.0.1", "", false, "127.0.0.1 hostname returns false"],
       ["192.168.1.100", "", false, "192.168.x hostname returns false"],
       ["example.com", "", true, "production hostname returns true"],
     ];
 
-    test.each(testCases)("hostname: %s, query: %s -> %s (%s)", (hostname, search, expected, description) => {
-      const mockWindow = {
-        location: { hostname, search },
-      };
+    test.each(testCases)(
+      "hostname: %s, query: %s -> %s (%s)",
+      (hostname, search, expected, _description) => {
+        const mockWindow = {
+          location: { hostname, search },
+        };
 
-      expect(shouldEnableCaching(mockWindow)).toBe(expected);
-    });
+        expect(shouldEnableCaching(mockWindow)).toBe(expected);
+      },
+    );
   });
 });

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -18,6 +18,7 @@ const {
   showSaveMessage,
   setupSettingsEventListeners,
   initializeSettings,
+  shouldEnableCaching,
 } = require("../public_html/search.js");
 
 describe("buildSearchUrl", () => {
@@ -532,6 +533,10 @@ describe("PWA Functions", () => {
             register: mockRegister,
           },
         },
+        location: {
+          search: "",
+          hostname: "example.com",
+        },
       };
 
       initializePWA(mockWindow);
@@ -802,6 +807,26 @@ describe("Settings Functions", () => {
       };
 
       expect(() => initializeSettings(mockWindow)).not.toThrow();
+    });
+  });
+
+  describe("shouldEnableCaching", () => {
+    const testCases = [
+      // [hostname, queryString, expected, description]
+      ["localhost", "?cache=force", true, "cache=force parameter returns true"],
+      ["example.com", "?cache=disable", false, "cache=disable parameter returns false"],
+      ["localhost", "", false, "localhost hostname returns false"],
+      ["127.0.0.1", "", false, "127.0.0.1 hostname returns false"],
+      ["192.168.1.100", "", false, "192.168.x hostname returns false"],
+      ["example.com", "", true, "production hostname returns true"],
+    ];
+
+    test.each(testCases)("hostname: %s, query: %s -> %s (%s)", (hostname, search, expected, description) => {
+      const mockWindow = {
+        location: { hostname, search },
+      };
+
+      expect(shouldEnableCaching(mockWindow)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add smart caching logic that automatically disables PWA caching during local development
- Eliminate the need to manually clear cache or constantly bump cache versions while developing
- Provide URL parameter controls for testing caching behavior when needed

## Changes
- **New `shouldEnableCaching()` function** with environment detection:
  - Default: No caching on `localhost`, `127.0.0.1`, `192.168.x` (dev-friendly)
  - Override: `?cache=force` enables caching on local development
  - Override: `?cache=disable` disables caching in production
- **Updated `initializePWA()`** to conditionally register service worker based on caching logic
- **Comprehensive unit tests** using data-driven test cases for all scenarios
- **Documentation** in CLAUDE.md explaining caching control parameters
- **Cache version bump** to v7 for fresh deployment

## Problem Solved
PWA caching was great for users but painful for development - every file change required manual cache clearing or version bumping. Now developers get instant file updates by default while still being able to test caching behavior when needed.

## Test plan
- [ ] Verify no service worker registration on `localhost:8000` (check DevTools → Application)
- [ ] Verify service worker registers on `localhost:8000?cache=force`
- [ ] Test that file changes appear immediately without cache=force
- [ ] Test that cached assets are served when cache=force is used
- [ ] Run unit tests to verify all caching logic scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)